### PR TITLE
Implement paging for github api requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var AWS = require('aws-sdk');
 // (see https://github.com/orgs/guardian/teams)
 var TEAMS_TO_FETCH = ['Digital CMS', 'OpsManager-SSHAccess', 'Editorial Tools SSHAccess', 'Guardian Frontend', 'Discussion', 'Data Technology', 'Teamcity', 'Deploy Infrastructure', 'Membership and Subscriptions', 'Domains platform', 'Commercial dev', 'Content Platforms']
 
-function githubApiRequest(path) {
+function githubApiRequest(path, page) {
   return rp({
     uri: 'https://api.github.com' + path,
     headers: {
@@ -16,12 +16,28 @@ function githubApiRequest(path) {
       'User-Agent': 'nodey'
     },
     qs: {
-        per_page: 100
+        per_page: 100,
+        page: page
     },
     json: true
   }).catch(function(err) {
     console.error(err);
   });
+}
+
+function pagedGithubApiRequest(path, page, teamList) {
+    if (teamList) {
+        return githubApiRequest(path, page).then(function(resp) {
+            if (resp.length === 0) {
+                return teamList;
+            }
+            return pagedGithubApiRequest(path, page+1, teamList.concat(resp));
+            })
+    } else {
+        return githubApiRequest(path, page).then(function(resp){
+            return pagedGithubApiRequest(path, page+1, resp)
+        })
+    }
 }
 
 function membersListToLogin(membersList) {
@@ -98,7 +114,7 @@ function filterTeamList(teamList) {
 }
 
 exports.handler = function (event, context) {
-  var teamList = githubApiRequest('/orgs/guardian/teams').then(filterTeamList);
+  var teamList = pagedGithubApiRequest('/orgs/guardian/teams', 1, null).then(filterTeamList);
   var botList = getGithubBots();
   var teamsWithKeys = teamList.then(function(tl) {
     return botList.then(function(bl) {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var AWS = require('aws-sdk');
 
 // add your github team name here to add your team's keys to the bucket
 // (see https://github.com/orgs/guardian/teams)
-var TEAMS_TO_FETCH = ['Digital CMS', 'OpsManager-SSHAccess', 'Editorial Tools SSHAccess', 'Guardian Frontend', 'Discussion', 'Data Technology', 'Teamcity', 'Deploy Infrastructure', 'Membership and Subscriptions', 'Domains platform', 'Commercial dev', 'Content Platforms']
+var TEAMS_TO_FETCH = ['Digital CMS', 'OpsManager-SSHAccess', 'Editorial Tools SSHAccess', 'Guardian Frontend', 'Discussion', 'Data Technology', 'Teamcity', 'Deploy Infrastructure', 'Membership and Subscriptions', 'Domains platform', 'Commercial dev', 'Content Platforms'];
 
 function githubApiRequest(path, page) {
   return rp({
@@ -28,10 +28,8 @@ function githubApiRequest(path, page) {
 function pagedGithubApiRequest(path, page, teamList) {
     if (teamList) {
         return githubApiRequest(path, page).then(function(resp) {
-            if (resp.length === 0) {
-                return teamList;
-            }
-            return pagedGithubApiRequest(path, page+1, teamList.concat(resp));
+            if (resp.length === 0) return teamList;
+            else return pagedGithubApiRequest(path, page+1, teamList.concat(resp));
             })
     } else {
         return githubApiRequest(path, page).then(function(resp){
@@ -62,10 +60,9 @@ function usernameListToKeysList(usernameList) {
   return Promise.all(usernameList.map(function (username) {
     return githubApiRequest('/users/' + username + '/keys').then(function(keyResult) {
       if (keyResult[0]) {
-        var userKeys = keyResult.map(function(key) {
+        return keyResult.map(function(key) {
           return key.key + ' ' + username;
         }).join('\n');
-        return userKeys;
       } else {
         console.log("No key for user " + username);
         return "";


### PR DESCRIPTION
We currently have exactly 100 teams in the guardian github account. Github returns a maximum of 100 elements, so for future teams to work we need to page through api responses. This is my attempt at doing that.
