### PR TITLE
Add data science team

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ var dynamoClient = new AWS.DynamoDB.DocumentClient()
 var TEAMS_TO_FETCH = ['Digital CMS', 'OpsManager-SSHAccess', 'Editorial Tools SSHAccess',
                       'Guardian Frontend', 'Discussion', 'Data Technology', 'Teamcity',
                       'Deploy Infrastructure', 'Membership and Subscriptions', 'Domains platform',
-                      'Commercial dev', 'Content Platforms', 'Multimedia', 'digital-department-website']
+                      'Commercial dev', 'Content Platforms', 'Multimedia', 'digital-department-website',
+                      'data science']
 
 function configFromDynamo(functionName) {
   var params = {


### PR DESCRIPTION
We're going to be baking AMIs for the data science team's [tailor](/guardian/tailor) project which will have the [s3-ssh-keys](https://amigo.gutools.co.uk/roles#s3-ssh-keys) role. We therefore need the data science team's keys to be available in the public s3 bucket so team members can log on to the EC2 instances.

@MahanaC @philwills @davidfurey 