### PR TITLE
Pass in a context when running lambda locally

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,5 +166,5 @@ exports.handler = function (event, context) {
 
 // For testing locally
 if (process.env["KEYS_TO_S3_RUN_LOCAL"] === "true") {
-  exports.handler();
+  exports.handler(null, {functionName: 'github-keys-to-s3'});
 }


### PR DESCRIPTION
For doing a local sanity check. Otherwise it errors at https://github.com/guardian/github-keys-to-s3-lambda/blob/master/index.js#L145

@philmcmahon 