### PR TITLE
Stop backing up index.js when updating/running the lambda locally

### DIFF
--- a/run-lambda-locally.sh
+++ b/run-lambda-locally.sh
@@ -3,7 +3,4 @@
 set -e
 
 export KEYS_TO_S3_RUN_LOCAL=true
-cp index.js index1.js
 node index.js
-rm index.js
-mv index1.js index.js

--- a/update-lambda.sh
+++ b/update-lambda.sh
@@ -2,10 +2,7 @@
 
 set -e
 
-cp index.js index1.js
 zip -r -q keysToS3Lambda.zip index.js node_modules/ package.json
-rm index.js
-mv index1.js index.js
 aws s3 cp keysToS3Lambda.zip s3://deploy-tools-dist/deploy/PROD/keys-to-S3/keysToS3Lambda.zip --profile deployTools
 aws lambda update-function-code --function-name github-keys-to-s3 --s3-bucket deploy-tools-dist --s3-key deploy/PROD/keys-to-S3/keysToS3Lambda.zip --profile deployTools --region eu-west-1
 rm keysToS3Lambda.zip


### PR DESCRIPTION
Now that the config is done within the lambda rather than being hard coded the scripts don't modify index.js so backing it up is no longer necessary.