### PR TITLE
Add identity team to list of keys to be fetched

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var TEAMS_TO_FETCH = ['Digital CMS', 'OpsManager-SSHAccess', 'Editorial Tools SS
                       'Guardian Frontend', 'Discussion', 'Data Technology', 'Teamcity',
                       'Deploy Infrastructure', 'Membership and Subscriptions', 'Domains platform',
                       'Commercial dev', 'Content Platforms', 'Multimedia', 'digital-department-website',
-                      'data science', 'Mobile Server-Side Staff'];
+                      'data science', 'Mobile Server-Side Staff', 'Identity'];
 
 function configFromDynamo(functionName) {
   var params = {


### PR DESCRIPTION
In the short term we'll be using this for identity mongo instances, but it will be good to standardise ssh access across the identity platform soon thereafter.