### PR TITLE
Add deployment steps to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ Lambda function used to store public keys for each team member on S3 to be
 used for authentication when logging into AWS instances via SSH. Keys are
 fetched from github for teams listed in TEAMS_TO_FETCH in index.js.
 
-You will need to submit a pull request to add your team's name on github (see 
+To get access to the bucket containing the shared keys, you'll need to add your
+account to the [bucket policy](https://github.com/guardian/deploy-tools-platform/tree/master/cloudformation/github-public-keys-bucket.yaml)
+Your AWS account id can be found in [prism](http://prism.gutools.co.uk/sources))
+
+You will also need to submit a pull request to add your team's name on github (see 
 [here](https://github.com/orgs/guardian/teams)) to TEAMS_TO_FETCH in
 [index.js](https://github.com/guardian/github-keys-to-s3-lambda/blob/master/index.js)
 to get the lambda to start fetching keys for your team.

--- a/README.md
+++ b/README.md
@@ -4,16 +4,19 @@ Lambda function used to store public keys for each team member on S3 to be
 used for authentication when logging into AWS instances via SSH. Keys are
 fetched from github for teams listed in TEAMS_TO_FETCH in index.js.
 
-To get access to the bucket containing the shared keys, you'll need to add your
-account to the [bucket policy](https://github.com/guardian/deploy-tools-platform/tree/master/cloudformation/github-public-keys-bucket.yaml)
-Your AWS account id can be found in [prism](http://prism.gutools.co.uk/sources))
-
-You will also need to submit a pull request to add your team's name on github (see 
+You will need to submit a pull request to add your team's name on github (see 
 [here](https://github.com/orgs/guardian/teams)) to TEAMS_TO_FETCH in
 [index.js](https://github.com/guardian/github-keys-to-s3-lambda/blob/master/index.js)
 to get the lambda to start fetching keys for your team.
 
 This lambda is designed to be used with the [ssh-keys role in amigo](https://amigo.gutools.co.uk/roles#s3-ssh-keys).
+
+Deployment
+-----
+
+1. (Suggested) switch to the version of node used by the lambda (currently 4.3)
+2. `npm install`
+3. `./update-lambda.sh` (requires deploy tools account credentials)
 
 Notes
 -----


### PR DESCRIPTION
Given my demonstration of how *not* to deploy this lambda, I've added the steps I took to do it successfully to the readme.

I think it makes a lot of sense to have this deployed via riff-raff again, but that will come later in another PR.