### PR TITLE
Add specific SSH access for Identity

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var TEAMS_TO_FETCH = ['Digital CMS', 'OpsManager-SSHAccess', 'Editorial Tools SS
                       'Guardian Frontend', 'Discussion', 'Data Technology', 'Teamcity',
                       'Deploy Infrastructure', 'Membership and Subscriptions', 'Domains platform',
                       'Commercial dev', 'Content Platforms', 'Multimedia', 'digital-department-website',
-                      'data science', 'Mobile Server-Side Staff', 'Identity'];
+                      'data science', 'Mobile Server-Side Staff', 'Identity', 'Identity SSH Access'];
 
 function configFromDynamo(functionName) {
   var params = {


### PR DESCRIPTION
Adding a new Identity team so that we can grant SSH access to a smaller subset of people.  Membership of the existing Identity team on github is required for contributing to a number of repositories, but we don't necessarily need to give those same people SSH access.

We should be able to remove the `Identity` team later once the new one is in full use.