### PR TITLE
Add reader revenue team to list of teams to fetch

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var dynamoClient = new AWS.DynamoDB.DocumentClient();
 // (see https://github.com/orgs/guardian/teams)
 var TEAMS_TO_FETCH = ['Digital CMS', 'OpsManager-SSHAccess', 'Editorial Tools SSHAccess',
                       'Guardian Frontend', 'Discussion', 'Data Technology', 'Teamcity',
-                      'Deploy Infrastructure', 'Membership and Subscriptions', 'Domains platform',
+                      'Deploy Infrastructure', 'Domains platform',
                       'Commercial dev', 'Content Platforms', 'Multimedia', 'digital-department-website',
                       'data science', 'Mobile Server-Side Staff', 'Identity', 'Identity SSH Access',
                       "Guardian Frontend Team", 'Investigations SSH Access', 'Reader Revenue'];

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var TEAMS_TO_FETCH = ['Digital CMS', 'OpsManager-SSHAccess', 'Editorial Tools SS
                       'Deploy Infrastructure', 'Membership and Subscriptions', 'Domains platform',
                       'Commercial dev', 'Content Platforms', 'Multimedia', 'digital-department-website',
                       'data science', 'Mobile Server-Side Staff', 'Identity', 'Identity SSH Access',
-                      "Guardian Frontend Team", 'Investigations SSH Access'];
+                      "Guardian Frontend Team", 'Investigations SSH Access', 'Reader Revenue'];
 
 function configFromDynamo(functionName) {
   var params = {


### PR DESCRIPTION
The Membership and Subscriptions team no longer exists on github, and appears to have been superceded by the Reader Revenue team. This PR adds this team to the job

@guardian/reader-revenue 