### PR TITLE
Bump to node 8.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 github-keys-to-s3-lambda
 ========================
+
+**DEPRECATED**: Please use [ssm-scala](https://github.com/guardian/ssm-scala) for future deployments.
+
 Lambda function used to store public keys for each team member on S3 to be
 used for authentication when logging into AWS instances via SSH. Keys are
 fetched from github for teams listed in TEAMS_TO_FETCH in index.js.

--- a/cloudformation/cfn.yaml
+++ b/cloudformation/cfn.yaml
@@ -56,7 +56,7 @@ Resources:
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt [KeysToS3LambdaRole, Arn]
-      Runtime: nodejs4.3
+      Runtime: nodejs8.10
       Timeout: 120
   ConfigTable:
     Type: AWS::DynamoDB::Table


### PR DESCRIPTION
Node 4.3 has been end-of-lifed by AWS so this PR bumps it to 8.10 to keep the lambda alive.
I've also added a note to the README that this project is deprecated.