### PR TITLE
Modernise and reduce scope

### DIFF
--- a/cloudformation/cfn.yaml
+++ b/cloudformation/cfn.yaml
@@ -12,7 +12,31 @@ Parameters:
     Type: String
   Stack:
     Type: String
+  PrivateSubnets:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: Private subnets of vpc
+  VPC:
+    Type: AWS::EC2::VPC::Id
+    Description: VPC to deploy into
+  GithubToken:
+    Type: String
+    Description: Github API OAuth Token
+  BucketName:
+    Type: String
+    Description: Bucket to put the keys in
+
 Resources:
+  LambdaSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Security group for github lambda - allow access to github
+      VpcId: !Ref VPC
+      SecurityGroupEgress:
+        CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: 443
+        ToPort: 443
+
   KeysToS3LambdaRole:
     Type: AWS::IAM::Role
     Properties:
@@ -36,13 +60,15 @@ Resources:
             Resource: !Sub arn:aws:s3:::${TargetBucket}/*
           - Effect: Allow
             Action:
-            - dynamodb:Scan
-            Resource: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${ConfigTable}
-          - Effect: Allow
-            Action:
             - logs:CreateLogGroup
             - logs:CreateLogStream
             - logs:PutLogEvents
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - ec2:DescribeNetworkInterfaces
+              - ec2:CreateNetworkInterface
+              - ec2:DeleteNetworkInterface
             Resource: "*"
   KeysToS3Lambda:
     Type: AWS::Lambda::Function
@@ -53,24 +79,19 @@ Resources:
         S3Key: !Sub ${Stack}/PROD/keys-to-S3/keysToS3Lambda.zip
       Description: A lambda function to fetch public keys for each team from github
         and store them in s3
+      Environment:
+        Variables:
+          BUCKET: !Ref BucketName
+          GITHUB_TOKEN: !Ref GithubToken
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt [KeysToS3LambdaRole, Arn]
       Runtime: nodejs8.10
       Timeout: 120
-  ConfigTable:
-    Type: AWS::DynamoDB::Table
-    Properties:
-      TableName: !Sub ${FunctionName}-config
-      AttributeDefinitions:
-        - AttributeName: key
-          AttributeType: S
-      KeySchema:
-        - AttributeName: key
-          KeyType: HASH
-      ProvisionedThroughput:
-        ReadCapacityUnits: 1
-        WriteCapacityUnits: 1
+      VpcConfig:
+        SubnetIds: !Ref PrivateSubnets
+        SecurityGroupIds:
+        - !Ref LambdaSecurityGroup
   TriggerRule:
     Type: AWS::Events::Rule
     Properties:

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ AWS.config.update({
 
 // add your github team name here to add your team's keys to the bucket
 // (see https://github.com/orgs/guardian/teams)
-var TEAMS_TO_FETCH = ['Discussion', 'Data Technology', 'Teamcity',
+var TEAMS_TO_FETCH = ['Data Technology', 'Teamcity',
                       'Deploy Infrastructure', 'Domains platform',
                       'Commercial dev', 'Multimedia', 'digital-department-website',
                       'data science', 'Investigations SSH Access', 'Reader Revenue'];

--- a/index.js
+++ b/index.js
@@ -8,35 +8,13 @@ AWS.config.update({
   region: "eu-west-1"
 });
 
-var dynamoClient = new AWS.DynamoDB.DocumentClient();
-
 // add your github team name here to add your team's keys to the bucket
 // (see https://github.com/orgs/guardian/teams)
-var TEAMS_TO_FETCH = ['OpsManager-SSHAccess',
-                      'Guardian Frontend', 'Discussion', 'Data Technology', 'Teamcity',
+var TEAMS_TO_FETCH = ['Discussion', 'Data Technology', 'Teamcity',
                       'Deploy Infrastructure', 'Domains platform',
-                      'Commercial dev', 'Content Platforms', 'Multimedia', 'digital-department-website',
-                      'data science', 'Mobile Server-Side Staff', 'Identity', 'Identity SSH Access',
-                      "Guardian Frontend Team", 'Investigations SSH Access', 'Reader Revenue'];
+                      'Commercial dev', 'Multimedia', 'digital-department-website',
+                      'data science', 'Investigations SSH Access', 'Reader Revenue'];
 
-function configFromDynamo(functionName) {
-  var params = {
-    TableName: functionName + "-config"
-  };
-  return new Promise(function (fulfill, reject) {
-    dynamoClient.scan(params, function(err, data) {
-      if (err) reject(err)
-      else fulfill(data);
-    });
-  }).then(function (res) {
-    console.log(res.Items);
-    var config = {};
-    res.Items.forEach(function(row) {
-      config[row.key] = row.value
-    });
-    return config;
-  });
-}
 
 function githubApiRequest(path, githubOAuthToken, page) {
   return rp({
@@ -141,28 +119,26 @@ function filterTeamList(teamList) {
 }
 
 exports.handler = function (event, context) {
-  console.log('context:', context)
+  console.log('context:', context);
 
-  var functionName = context.functionName;
-  var configPromise = configFromDynamo(functionName);
+  const bucket = process.env.BUCKET;
+  const githubOauthToken = process.env.GITHUB_TOKEN;
 
-  configPromise.then(function (config) {
-    var botList = getGithubBots(config.githubOAuthToken);
-    var teams = pagedGithubApiRequest('/orgs/guardian/teams', config.githubOAuthToken, 1, null).then(filterTeamList);
+  var botList = getGithubBots(githubOauthToken);
+  var teams = pagedGithubApiRequest('/orgs/guardian/teams',githubOauthToken, 1, null).then(filterTeamList);
 
-    Promise.all([botList, teams]).then(function(bAndT) {
-      var bl = bAndT[0];
-      var tl = bAndT[1];
-      return tl.map(function(t) { return teamToTeamKeysObject(t, bl, config.githubOAuthToken);});
-    }).then(function(twk) {
-      console.log("There are " + twk.length + " teams to post: " + twk.map(function(team){return team.teamName;}));
-      twk.map(function(team) {
-        team.teamMembers.then(function(members) {
-          postToS3(config.bucket, team.teamName, members);
-        });
+  Promise.all([botList, teams]).then(function(bAndT) {
+    var bl = bAndT[0];
+    var tl = bAndT[1];
+    return tl.map(function(t) { return teamToTeamKeysObject(t, bl, githubOauthToken);});
+  }).then(function(twk) {
+    console.log("There are " + twk.length + " teams to post: " + twk.map(function(team){return team.teamName;}));
+    twk.map(function(team) {
+      team.teamMembers.then(function(members) {
+        postToS3(bucket, team.teamName, members);
       });
-    })
-  });
+    });
+  })
 };
 
 // For testing locally

--- a/package.json
+++ b/package.json
@@ -3,15 +3,15 @@
     "dependencies": {
         "request-promise": "1.0.2",
         "promise": "7.0.4",
-        "aws-sdk":"2.2.20",
+        "aws-sdk": "2.2.20",
         "node-riffraff-artefact": "^1.3.2"
     },
     "scripts": {
-      "riffraff-artefact": "./node_modules/.bin/riffraff-artefact"
+        "riffraff-artefact": "./node_modules/.bin/riffraff-artefact"
     },
-    "repository" : {
-      "type" : "git",
-      "url" : "https://github.com/guardian/github-keys-to-s3-lambda"
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/guardian/github-keys-to-s3-lambda"
     },
     "description": "A lambda function to copy github public keys to s3",
     "cloudformation": "cloudformation/cfn.yaml"


### PR DESCRIPTION
This PR:
 - Moves the lambda into the deploy tools VPC
 - Limits access to a single egress rule (to the whole internet) on port 443
 - Removes dynamo config stuff, instead using environment variables
 - Reduces the number of teams for which we fetch keys for. @alexduf @jfsoul am I right in assuming that identity/map aren't using this at all anymore?


(This change is live already)